### PR TITLE
Fix sidebar arrows.

### DIFF
--- a/assets/css/customstyles.css
+++ b/assets/css/customstyles.css
@@ -428,7 +428,7 @@ a.accordion-toggle, a.accordion-collapsed {
 .nav li > a > span:after {
     content: '\25be';
 }
-.nav li.open > a > span:after {
+.nav li.active > a > span:after {
     content: '\25b4';
 }
 


### PR DESCRIPTION
Just discovered Singularity, am excited.

Recognized the site was derived from Tom Johnson's [Jekyll Documentation Theme](https://github.com/tomjohnson1492/documentation-theme-jekyll) or at least they share a common ancestor (I'm using it for a couple of projects).

I also noticed that the Singularity site's sidebar suffers from the same CSS bug [that I fixed for Tom](https://github.com/tomjohnson1492/documentation-theme-jekyll/pull/65).

This PR is a minimal fix to the CSS.

I think that the arrow that the existing CSS uses for the open/active element is *ugly*.  There are a couple of Font Awesome glyphs that look better (you're already loading FA, so no add'l overhead).   Here's what I'm using on my site.

```
.nav li > a > span:after {
   font-family: FontAwesome;
   content: "\f105";

}
.nav li.active > a > span:after {
   font-family: FontAwesome;
   content: "\f107";
}
```