### PR TITLE
Feature/getting started improvements

### DIFF
--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -23,7 +23,7 @@ sudo make install
 
 It's easiest to build an image on a "compatible" host.  Here's a quick
 recipe to build a CentOS 7 image on a CentOS host.  See
-the [bootstrapping section][bootstrapping-readme] of the README for
+the [bootstrapping section][readme-bootstrapping] of the README for
 the backstory and the [tutorials] for deeper advice.
 
 1. Create a file named `centos.def` that contains the following lines.

--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -44,7 +44,7 @@ the backstory and the [tutorials] for deeper advice.
 
 ### Shell into container
 ```bash
-singularity shell --contain /tmp/Centos7.img 
+$ singularity shell --contain /tmp/Centos7.img 
 Singularity.Centos7.img> ps aux
 USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 gmk           1  0.0  0.3 115372  1768 pts/6    S    12:23   0:00 /bin/bash --norc --noprofile
@@ -55,31 +55,31 @@ Singularity.Centos7.img> exit
 ### I am the same user inside the container as outside the container
 
 ```bash
-id
+$ id
 uid=1000(gmk) gid=1000(gmk) groups=1000(gmk),10(wheel),2222(testgroup)
-singularity exec /tmp/Centos7.img id
+$ singularity exec /tmp/Centos7.img id
 uid=1000(gmk) gid=1000(gmk) groups=1000(gmk),10(wheel),2222(testgroup)
 ````
 
 ### Files on the host can be reachable from within the container
 ```bash
-echo "Hello World" > /home/gmk/testfile
-singularity exec /tmp/Centos7.img cat /home/gmk/testfile 
+$ echo "Hello World" > /home/gmk/testfile
+$ singularity exec /tmp/Centos7.img cat /home/gmk/testfile 
 Hello World
 ````
 
 ### Switching operating systems is as easy as pointing to a different image!
 ```bash
-singularity exec /tmp/Centos7.img cat /etc/redhat-release 
+$ singularity exec /tmp/Centos7.img cat /etc/redhat-release 
 CentOS Linux release 7.2.1511 (Core) 
 
-singularity exec /tmp/SL6.img cat /etc/redhat-release 
+$ singularity exec /tmp/SL6.img cat /etc/redhat-release 
 Scientific Linux release 6.8 (Carbon)
 
-singularity exec /tmp/Debian-stable.img cat /etc/debian_version
+$ singularity exec /tmp/Debian-stable.img cat /etc/debian_version
 8.5
 
-singularity exec /tmp/Ubuntu-trusty.img cat /etc/lsb-release 
+$ singularity exec /tmp/Ubuntu-trusty.img cat /etc/lsb-release 
 DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=14.04
 DISTRIB_CODENAME=trusty

--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -9,12 +9,12 @@ toc: false
 ## Installation Quick Start
 
 ```bash
-git clone {{ site.repo }}.git
-cd singularity
-./autogen.sh
-./configure --prefix=/usr/local
-make
-sudo make install
+$ git clone {{ site.repo }}.git
+$ cd singularity
+$ ./autogen.sh
+$ ./configure --prefix=/usr/local
+$ make
+$ sudo make install
 ```
 
 ## Command Quick Start

--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -19,28 +19,41 @@ $ sudo make install
 
 ## Command Quick Start
 
-### Create a Centos7 image from a CentOS host
+### Import a Centos7 image from Docker Hub
 
-It's easiest to build an image on a "compatible" host.  Here's a quick
-recipe to build a CentOS 7 image on a CentOS host.  See
-the [bootstrapping section][readme-bootstrapping] of the README for
-the full story and the [tutorials] for deeper advice.
+The quickest way to get an image is to import it from Docker Hub.
+Here's an example that creates an empty image, imports the current
+CentOS 7 Docker image and proves that we got what we wanted.
 
-1. Create a file named `centos.def` that contains the following lines.
+```terminal
+$ singularity create /tmp/Centos7.img
+Creating a new image with a maximum size of 768MiB...
+Executing image create helper
+Formatting image with ext3 file system
+Done.
+$ singularity import /tmp/Centos7.img docker://centos:7
+Cache folder set to /root/.singularity/docker
+Extracting /root/.singularity/docker/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar.gz
+Extracting /root/.singularity/docker/sha256:45a2e645736c4c66ef34acce2407ded21f7a9b231199d3b92d6c9776df264729.tar.gz
+Bootstrap initialization
+No bootstrap definition passed, updating container
+Executing Prebootstrap module
+Executing Postbootstrap module
+Done.
+$ singularity shell --contain /tmp/Centos7.img
+Singularity: Invoking an interactive shell within container...
 
-   ```
-   BootStrap: yum
-   OSVersion: 7
-   MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
-   Include: yum
-   ```
+Singularity.Centos7.img> cat /etc/redhat-release
+CentOS Linux release 7.3.1611 (Core)
+Singularity.Centos7.img> exit
+exit
+$
+```
 
-2. Create and bootstrap the image:
-
-   ```bash
-   $ sudo singularity create /tmp/Centos7.img
-   $ sudo singularity bootstrap /tmp/Centos7.img centos.def
-   ```
+This approach works with Docker's basic Alpine Linux
+(`docker://alpine`), Debian (`docker://debian`), Ubuntu
+(`docker://ubuntu`) and more.  You'll find the details on
+the [Singularity and Docker][docs-docker] page.
 
 ### Shell into container
 ```bash
@@ -88,4 +101,5 @@ DISTRIB_DESCRIPTION="Ubuntu 14.04 LTS"
 
 {% include links.html %}
 
+[docs-docker]: /docs-docker
 [readme-bootstrapping]: https://github.com/singularityware/singularity/blob/master/README.md#bootstrapping-new-images

--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -19,6 +19,29 @@ sudo make install
 
 ## Command Quick Start
 
+### Create a Centos7 image from a CentOS host
+
+It's easiest to build an image on a "compatible" host.  Here's a quick
+recipe to build a CentOS 7 image on a CentOS host.  See
+the [bootstrapping section][bootstrapping-readme] of the README for
+the backstory and the [tutorials] for deeper advice.
+
+1. Create a file named `centos.def` that contains the following lines.
+
+   ```
+   BootStrap: yum
+   OSVersion: 7
+   MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+   Include: yum
+   ```
+
+2. Create and bootstrap the image:
+
+   ```bash
+   $ sudo singularity create /tmp/Centos-7.img
+   $ sudo singularity bootstrap /tmp/Centos-7.img centos.def
+   ```
+
 ### Shell into container
 ```bash
 singularity shell --contain /tmp/Centos7.img 
@@ -64,3 +87,5 @@ DISTRIB_DESCRIPTION="Ubuntu 14.04 LTS"
 ````
 
 {% include links.html %}
+
+[readme-bootstrapping]: https://github.com/singularityware/singularity/blob/master/README.md#bootstrapping-new-images

--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -38,8 +38,8 @@ the backstory and the [tutorials] for deeper advice.
 2. Create and bootstrap the image:
 
    ```bash
-   $ sudo singularity create /tmp/Centos-7.img
-   $ sudo singularity bootstrap /tmp/Centos-7.img centos.def
+   $ sudo singularity create /tmp/Centos7.img
+   $ sudo singularity bootstrap /tmp/Centos7.img centos.def
    ```
 
 ### Shell into container

--- a/pages/docs/overview/start.md
+++ b/pages/docs/overview/start.md
@@ -24,7 +24,7 @@ $ sudo make install
 It's easiest to build an image on a "compatible" host.  Here's a quick
 recipe to build a CentOS 7 image on a CentOS host.  See
 the [bootstrapping section][readme-bootstrapping] of the README for
-the backstory and the [tutorials] for deeper advice.
+the full story and the [tutorials] for deeper advice.
 
 1. Create a file named `centos.def` that contains the following lines.
 


### PR DESCRIPTION
I found the quick start frustrating because I had no idea how to create an image.

I eventually found a simple recipe in the repo's README.md.

This PR duplicates it in the quick start section.  It's CentOS specific but it gives pointers to additional info and discussion.

Also, minor edits so that all of the examples showed similar shell prompts.