### PR TITLE
Correct small spelling error

### DIFF
--- a/_data/sidebars/admin_docs.yml
+++ b/_data/sidebars/admin_docs.yml
@@ -10,7 +10,7 @@ entries:
     output: web
     folderitems:
 
-    - title: Administation QuickStart
+    - title: Administration QuickStart
       output: web, pdf
       url: /admin-guide
 


### PR DESCRIPTION
Hello! This pull request is to correct a small typo I noticed on the website. This changes the sidebar item from "Administation QuickStart" to "Administration QuickStart". Thank you!