### PR TITLE
add: Mac + Windows installation via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:17.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /opt
+RUN apt-get update -qq \
+    && apt-get install -yq --no-install-recommends autoconf \
+                                                   automake \
+                                                   g++ \
+                                                   gcc \
+                                                   ca-certificates \
+                                                   git \
+                                                   libtool \
+                                                   make \
+                                                   python \
+                                                   sudo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && git clone https://github.com/singularityware/singularity.git \
+    && cd singularity \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr/local \
+    && make \
+    && sudo make install \
+    && rm -rf /opt/singularity \
+    && apt-get purge -yq --auto-remove autoconf automake g++ gcc git make
+
+WORKDIR /home

--- a/pages/docs/install/install-mac.md
+++ b/pages/docs/install/install-mac.md
@@ -1,5 +1,5 @@
 ---
-title: Running Singularity with Vagrant (Mac)
+title: Running Singularity with Vagrant or Docker (Mac)
 sidebar: main_sidebar
 permalink: install-mac
 folder: docs
@@ -44,3 +44,21 @@ vagrant ssh
 ```
 
 Remember that the VM is running in the background because we started it via the command `vagrant up`. You can shut the VM down using the command 'vagrant halt' when you no longer need it.
+
+---
+
+It is also possible to run Singularity on your Mac via Docker. Use the command `docker pull kaczmarj/singularity` to pull the latest, pre-built Docker image containing Singularity. You can also build a Docker image from scratch using the [Dockerfile](/Dockerfile) in this repository. The Singularity Docker image must be run in [prileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+
+Example:
+
+```shellsession
+host-machine:/ me$ docker run --rm -it --privileged kaczmarj/singularity
+root@2e7fe1bd3e27:/home# singularity run shub://singularityhub/scientific-linux:master
+Cache folder set to /root/.singularity/shub
+Found image singularityhub/scientific-linux:master
+Downloading image... f5be5daaf80b208c2dd1af7da9cc83e742043606.img.gz
+('Decompressing', u'/root/.singularity/shub/f5be5daaf80b208c2dd1af7da9cc83e742043606.img.gz')
+This is what happens when you run the container...
+root@2e7fe1bd3e27:/home# exit
+host-machine:/ me$
+```

--- a/pages/docs/install/install-windows.md
+++ b/pages/docs/install/install-windows.md
@@ -1,8 +1,8 @@
 ---
-title: Running Singularity with Vagrant (Windows)
+title: Running Singularity with Docker (Windows)
 sidebar: main_sidebar
 permalink: install-windows
 folder: docs
 ---
 
-Windows? Ugh, I suppose we will write this. I heard it has a command line? Will get around to this eventually. Nothing here for now, folks.
+It is possible to run Singularity on your Windows machine via Docker. Use the command `docker pull kaczmarj/singularity` to pull the latest, pre-built Docker image containing Singularity. You can also build a Docker image from scratch using the [Dockerfile](/Dockerfile) in this repository. The Singularity Docker image must be run in [prileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).


### PR DESCRIPTION
This PR adds: 

- an alternative to Singularity via Vagrant for macOS users
- a Dockerfile that builds a minimal Docker image containing Singularity
- instructions to install and use the Docker image on Mac and Windows (not tested on Windows)

As a test, I set up an automated build on [DockerHub](https://hub.docker.com/r/kaczmarj/singularity/) that builds a Docker image from the Dockerfile in my fork of this repository. This image is available for download via the command `docker pull kaczmarj/singularity`. If this PR is accepted, a dedicated DockerHub repository could be created to host the Singularity Docker image.

Thank you.