### PR TITLE
Mpi update

### DIFF
--- a/pages/docs/admin-docs/docs-hpc.md
+++ b/pages/docs/admin-docs/docs-hpc.md
@@ -30,8 +30,8 @@ From the above image you can follow the invocation pathway:
 8. At this point the processes within the container run as they would normally directly on the host at full bandwidth! This entire process happens behind the scenes, and from the user's perspective running via MPI is as simple as just calling mpirun on the host as they would normally.
 
 #### Code
-Below is an example snippet of building and installing OpenMPI into a container and then running an example MPI program through Singularity. 
- 
+Below is an example snippet of building and installing OpenMPI into a container and then running an example MPI program through Singularity.
+
 ```bash
 $ # Include the appropriate development tools into the container (notice we are calling
 $ # singularity as root and the container is writeable)
@@ -99,5 +99,5 @@ Process 19 exiting
 ### Notes
 Supported Open MPI Version(s): To achieve proper container'ized Open MPI support, you must use Open MPI version 2.1.
 
-Open MPI version 2.1.0 includes a bug in its configure script affecting some interfaces (at least Mellanox cards operating in RoCE mode useing libmxm)
+Open MPI version 2.1.0 includes a bug in its configure script affecting some interfaces (at least Mellanox cards operating in RoCE mode using libmxm)
 The example should work fine on most hardware but if you have an issue, try running from master (it has been patched upstream)

--- a/pages/docs/admin-docs/docs-hpc.md
+++ b/pages/docs/admin-docs/docs-hpc.md
@@ -38,10 +38,13 @@ $ # singularity as root and the container is writeable)
 $ sudo singularity exec -w /tmp/Centos-7.img yum groupinstall "Development Tools"
 $
 $ # Clone the OpenMPI GitHub master branch in current directory (on host)
-$ git clone https://github.com/open-mpi/ompi.git
-$ cd ompi
+$ wget https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.0.tar.bz2
+$ tar jtf openmpi-2.1.0.tar.bz2
+$ cd openmpi-2.1.0
 $
 $ # Build OpenMPI in the working directory, using the tool chain within the container
+$ # This step is unusual in a stable release but there is a bug in the configure script
+$ # affecting some interfaces
 $ singularity exec /tmp/Centos-7.img ./autogen.pl
 $ singularity exec /tmp/Centos-7.img ./configure --prefix=/usr/local
 $ singularity exec /tmp/Centos-7.img make
@@ -94,4 +97,7 @@ Process 19 exiting
 ```
 
 ### Notes
-Supported Open MPI Version(s): To achieve proper container'ized Open MPI support, you must use Open MPI version 2.1 which at the time of this writing has not been released yet. The above example builds from the current master development branch of Open MPI.
+Supported Open MPI Version(s): To achieve proper container'ized Open MPI support, you must use Open MPI version 2.1.
+
+Open MPI version 2.1.0 includes a bug in its configure script affecting some interfaces (at least Mellanox cards operating in RoCE mode useing libmxm)
+The example should work fine on most hardware but if you have an issue, try running from master (it has been patched upstream)


### PR DESCRIPTION
Hi,
Open MPI 2.1.0 has been released so in theory this example should no longer need to be run from Master,

HOWEVER:

1) Open MPI 2.1.0 has a bug which took our site a long time to work around and now I can't find the correct docs on how we worked around. I think the step to ./autogen.pl should fix it. Its mitigated by the fact that IIRC it only affects installs using the Mellanox libmxm library

2) I haven't actually tested the updated script!

3) I actually tried a similar procedure on a slurm cluster with srun instead of mpirun and using Open MPI 1.10.3 and it appears to work. Its not clear to me that the statement "you must use at least version 2.1" is actually true.

As such, feel free to reject my PR and just update the line to indicate that 2.1 has been released but the example runs from Master anyway ;-) I was on the verge of not making the PR and telling @V 'No' for all the above reasons. Up to you to decide

Cheers,
--
Chris.
