### PR TITLE
start from vagrant box bento/ubuntu-16.04

### DIFF
--- a/pages/docs/install/install-mac.md
+++ b/pages/docs/install/install-mac.md
@@ -20,7 +20,7 @@ brew cask install vagrant-manager
 # generate a template Vagrantfile for "bento/ubuntu-16.04"
 mkdir singularity-vm
 cd singularity-vm
-vagrant init ubuntu/xenial64
+vagrant init bento/ubuntu-16.04
 
 # Build and start the Vagrant hosted VM
 vagrant up --provider virtualbox

--- a/pages/docs/install/install-mac.md
+++ b/pages/docs/install/install-mac.md
@@ -17,7 +17,7 @@ brew cask install vagrant
 brew cask install vagrant-manager
 
 # Create a working directory for the Vagrant configuration and
-# generate a template Vagrantfile for "ubuntu/xenial64"
+# generate a template Vagrantfile for "bento/ubuntu-16.04"
 mkdir singularity-vm
 cd singularity-vm
 vagrant init ubuntu/xenial64


### PR DESCRIPTION
Replacing the initial vagrant box from "ubuntu/trusty64" with "ubuntu/xenial64" was a great move :
-  xenial is the latest ubuntu long term support release, 
-  also  this avoids an issue which is specific to older versions of ubuntu : when running multiprocessing python inside the image the OS needs to create temporary files in /run/shm and /run/lock and this does not work unless the /etc/singularity/singularity.conf is modified with an additional  line:  "bind path = /run" )
However when testing more, I found that box the ubuntu/xenial64 does not have a system python2 installed, just a python3,  Because of that , several steps fail unless python2 is installed:  some python scripts have a she-bang line like this:
#!/usr/bin/env python and in absence of python2 , the python command is not found. So this is another hassle which would need to be documented in the instructions 
The solution I found is to use an alternative ubuntu1604 box from the bento project : http://chef.github.io/bento/ Bento is an impressive project and their vagrant boxes are well made and well regarded. https://atlas.hashicorp.com/bento