### PR TITLE
Vagrant Cloud repository page

### DIFF
--- a/pages/docs/install/install-mac.md
+++ b/pages/docs/install/install-mac.md
@@ -25,27 +25,26 @@ brew cask install vagrant-manager
 
 ## Option 1: Singularityware Vagrant Box
 
-We are maintaining a set of Vagrant Boxes via <a href="https://atlas.hashicorp.com/" target="_blank">Atlas</a>, one of <a href="https://www.hashicorp.com/#open-source-tools" target="_blank">Hashicorp</a> many tools that likely you've used and haven't known it. We currently have boxes for the following versions of Singularity:
-
- - [singularityware/singularity-2.2.99](https://atlas.hashicorp.com/singularityware/boxes/singularity-2.2.99)
- - [singularityware/singularity-2.3](https://atlas.hashicorp.com/singularityware/boxes/singularity-2.3)
- - [singularityware/singularity-2.3.1](https://atlas.hashicorp.com/singularityware/boxes/singularity-2.3.1)
+We are maintaining a set of Vagrant Boxes via <a href="https://www.vagrantup.com" target="_blank">Vagrant Cloud</a>, one of <a href="https://www.hashicorp.com/#open-source-tools" target="_blank">Hashicorp</a> many tools that likely you've used and haven't known it. The current stable version of Singularity is available here:
+ - [singularityware/singularity-2.3.1](https://app.vagrantup.com/singularityware/boxes/singularity-2.3.1/versions/2.3.1)
+ 
+For other versions of Singularity see [our Vagrant Cloud repository](https://app.vagrantup.com/singularityware)
 
 ```bash
 mkdir singularity-vm
 cd singularity-vm
-vagrant init singularityware/singularity-2.3
+vagrant init singularityware/singularity-2.3.1
 vagrant up
 vagrant ssh
 ```
 
-You are then ready to go with Singularity 2.3!
+You are then ready to go with Singularity 2.3.1!
 
 ```
 vagrant@vagrant:~$ which singularity
 /usr/local/bin/singularity
 vagrant@vagrant:~$ singularity --version
-2.3-master.gadf5259
+2.3.1-master.dist
 vagrant@vagrant:~$ singularity create test.img
 Initializing Singularity image subsystem
 Opening image file: test.img

--- a/pages/docs/install/install-mac.md
+++ b/pages/docs/install/install-mac.md
@@ -44,7 +44,7 @@ You are then ready to go with Singularity 2.3.1!
 vagrant@vagrant:~$ which singularity
 /usr/local/bin/singularity
 vagrant@vagrant:~$ singularity --version
-2.3.1-master.dist
+2.3.1-dist
 vagrant@vagrant:~$ singularity create test.img
 Initializing Singularity image subsystem
 Opening image file: test.img

--- a/pages/docs/install/install-windows.md
+++ b/pages/docs/install/install-windows.md
@@ -18,11 +18,10 @@ First, install the following software:
 
 ## Singularityware Vagrant Box
 
-We are maintaining a set of Vagrant Boxes via <a href="https://atlas.hashicorp.com/" target="_blank">Atlas</a>, one of <a href="https://www.hashicorp.com/#open-source-tools" target="_blank">Hashicorp</a> many tools that likely you've used and haven't known it. We currently have boxes for the following versions of Singularity:
-
- - [singularityware/singularity-2.2.99](https://atlas.hashicorp.com/singularityware/boxes/singularity-2.2.99)
- - [singularityware/singularity-2.3](https://atlas.hashicorp.com/singularityware/boxes/singularity-2.3)
- - [singularityware/singularity-2.3.1](https://atlas.hashicorp.com/singularityware/boxes/singularity-2.3.1)
+We are maintaining a set of Vagrant Boxes via <a href="https://www.vagrantup.com" target="_blank">Vagrant Cloud</a>, one of <a href="https://www.hashicorp.com/#open-source-tools" target="_blank">Hashicorp</a> many tools that likely you've used and haven't known it. The current stable version of Singularity is available here:
+ - [singularityware/singularity-2.3.1](https://app.vagrantup.com/singularityware/boxes/singularity-2.3.1/versions/2.3.1)
+ 
+For other versions of Singularity see [our Vagrant Cloud repository](https://app.vagrantup.com/singularityware)
 
 Run GitBash. The default home directory will be C:\Users\your_username
 
@@ -40,7 +39,7 @@ You are then ready to go with Singularity 2.3.1!
 vagrant@vagrant:~$ which singularity
 /usr/local/bin/singularity
 vagrant@vagrant:~$ singularity --version
-2.3-master.gadf5259
+2.3.1-dist
 vagrant@vagrant:~$ singularity create test.img
 Initializing Singularity image subsystem
 Opening image file: test.img


### PR DESCRIPTION
Atlas service has been moved over to Vagrant Cloud. 
Also link to our repsoitory page on Vagrant Cloud for older versions of the vagrant box.