### PR TITLE
change logo to scroll with sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,10 +1,10 @@
 {% include custom/sidebarconfigs.html %}
 
-{% if site.logo %}
-<div class="shiny"><a href="\"><figure><img src="{{ site.logo }}" class="sidebar-logo"/></figure></a></div>
-{% endif %}
 
 <ul id="mysidebar" class="nav">
+    {% if site.logo %}
+        <div class="shiny"><a href="\"><figure><img src="{{ site.logo }}" class="sidebar-logo"/></figure></a></div>
+    {% endif %}
     <li class="sidebarTitle">{{sidebar[0].title}}</li>
     {% for entry in sidebar %}
     {% for folder in entry.folders %}


### PR DESCRIPTION
This isn't ready to be merged.  I need some help.  

I think it's silly that the Singularity logo gets left behind at the top of the page when you scroll down. 
 It's always bothered me.   Here I moved the logo into the sidebar and now it scrolls along with everything else, but there is a new problem.  

Since it is now part of the side bar, the background changes color when you hover the mouse over it.  It's very unsightly.  

I tried editing the logo in inkscape and placing a white rectangle in the background.  That works for a portion of the box, but the logo is being automatically resized to fit in a small portion of the box, so there is now way to fill in the entire background.  

Does anyone know if there is a way to turn off the highlight-with-mouse-hover feature for this item in the sidebar?