### PR TITLE
Add autofs bug path documentation and troubleshooting

### DIFF
--- a/pages/docs/admin-docs/advanced-config.md
+++ b/pages/docs/admin-docs/advanced-config.md
@@ -48,6 +48,8 @@ In addition to the system bind points as specified within this configuration fil
 
 Singularity will automatically disable this feature if the host does not support the prctl option `PR_SET_NO_NEW_PRIVS`. In addition, `enable overlay` must be set to `yes` and the host system must support overlayFS (generally kernel versions 3.18 and later) for users to bind host directories to bind points that do not already exist in the container. 
 
+### AUTOFS BUG PATH (string)
+With some autofs version, Singularity fails to run with "Too many levels of symbolic links" error when specified bind path (via configuration file or command line argument -B) are located in an autofs mount point. With this directive you can specify any number of autofs mount points generating errors.
 
 ## Logging
 In order to facilitate monitoring and auditing, Singularity will syslog() every action and error that takes place to the `LOCAL0` syslog facility. You can define what to do with those logs in your syslog configuration.

--- a/pages/docs/admin-docs/advanced-config.md
+++ b/pages/docs/admin-docs/advanced-config.md
@@ -49,7 +49,10 @@ In addition to the system bind points as specified within this configuration fil
 Singularity will automatically disable this feature if the host does not support the prctl option `PR_SET_NO_NEW_PRIVS`. In addition, `enable overlay` must be set to `yes` and the host system must support overlayFS (generally kernel versions 3.18 and later) for users to bind host directories to bind points that do not already exist in the container. 
 
 ### AUTOFS BUG PATH (string)
-With some autofs version, Singularity fails to run with "Too many levels of symbolic links" error when specified bind path (via configuration file or command line argument -B) are located in an autofs mount point. With this directive you can specify any number of autofs mount points generating errors.
+With some versions of autofs, Singularity will fail to run with a "Too many levels of symbolic links" error. This error happens by way of a user requested bind (done with -B/--bind) or one specified via the configuration file. To handle this, you will want to specify those paths using this directive. For example:
+```bash
+autofs bug path = /share/PI
+```
 
 ## Logging
 In order to facilitate monitoring and auditing, Singularity will syslog() every action and error that takes place to the `LOCAL0` syslog facility. You can define what to do with those logs in your syslog configuration.

--- a/pages/docs/overview/faq.md
+++ b/pages/docs/overview/faq.md
@@ -328,4 +328,19 @@ To add /usr/local/bin to the default sudo search path, run the program visudo wh
 ```bash
 Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 ```
+
+### How to resolve "Too many levels of symbolic links" error
+Running singularity failed with "Too many levels of symbolic links" error
+
+```bash
+$ singularity run -B /apps container.img
+ERROR : There was an error binding the path /apps: Too many levels of symbolic links
+ABORT : Retval = 255
+```
+
+You got this error because /apps directory is an autofs mount point. You can fix it by editing singularity.conf and adding the following directive with corresponding path:
+```bash
+autofs bug path = /apps
+```
+
 {% include links.html %}


### PR DESCRIPTION
My english level will certainly requires some correction.
The following directive/fix is available in singularity dev branch

This snippet add documentation for new autofs bug path configuration directive in order to fix "Too many levels of symbolic links" errors