### PR TITLE
moving the quickstart menu to the top

### DIFF
--- a/_data/sidebars/user_docs.yml
+++ b/_data/sidebars/user_docs.yml
@@ -11,16 +11,16 @@ entries:
 
     folderitems:
 
+    - title: Quick Start
+      url: /quickstart
+      output: web, pdf
+
     - title: Introduction
       url: /user-guide
       output: web, pdf
 
     - title: Installation
       url: /docs-installation
-      output: web, pdf
-
-    - title: Quick Start
-      url: /quickstart
       output: web, pdf
 
     - title: Build a Container


### PR DESCRIPTION
I think quickstart should be the first thing a user sees to save them time if they are in a hurry.  