### PR TITLE
Correct build links

### DIFF
--- a/pages/docs/user-docs/action-bootstrap.md
+++ b/pages/docs/user-docs/action-bootstrap.md
@@ -6,9 +6,9 @@ folder: docs
 toc: false
 ---
 
-> Note: The bootstrap command is deprecated for Singularity Version 2.4. You should use [build](/build-a-container) instead.
+> Note: The bootstrap command is deprecated for Singularity Version 2.4. You should use [build](/docs-build-container) instead.
 
-Bootstrapping was the original way (for Singularity versions prior to 2.4) to install an operating system and then configure it appropriately for a specified need. Bootstrap is very similar to build, except that it by default uses an <a href="https://en.wikipedia.org/wiki/Ext3" target="_blank">ext3</a> filesystem and allows for writability. The images unfortunately are not immutable in this way, and can degrade over time. As of 2.4, bootstrap is still supported for Singularity, however we encourage you to use [build](/build-a-container) instead.
+Bootstrapping was the original way (for Singularity versions prior to 2.4) to install an operating system and then configure it appropriately for a specified need. Bootstrap is very similar to build, except that it by default uses an <a href="https://en.wikipedia.org/wiki/Ext3" target="_blank">ext3</a> filesystem and allows for writability. The images unfortunately are not immutable in this way, and can degrade over time. As of 2.4, bootstrap is still supported for Singularity, however we encourage you to use [build](/docs-build-container) instead.
 
 
 ## Quick Start


### PR DESCRIPTION
The links from the bootstrap page to the container build page were 404'ing due to incorrect URLs