### PR TITLE
adding flags page and links to it.

### DIFF
--- a/pages/docs/user-docs/action-exec.md
+++ b/pages/docs/user-docs/action-exec.md
@@ -32,6 +32,9 @@ Use the `instance://<instance name>` syntax like so:
 $ singularity exec instance://my-instance cat /etc/os-release
 ```
 
+### Runtime Flags
+If you are interested in containing an environment or filesystem locations, we highly recommend that you look at the `singularity run help` and our documentation on [flags](/action-flags) to better customize this command.
+
 ### Special Characters
 And properly passing along special characters to the program within the container.
 

--- a/pages/docs/user-docs/action-flags.md
+++ b/pages/docs/user-docs/action-flags.md
@@ -1,0 +1,47 @@
+---
+title: Singularity Action Flags
+sidebar: user_docs
+permalink: action-flags
+folder: docs
+toc: false
+---
+
+For each of `exec`, `run`, and `shell`, there are a few important flags that we want to note for new users that have substantial impact on using your container. While we won't include the complete list of run options (for this complete list see `singularity run --help` or more generally `singularity <action> --help`) we will review some highly useful flags that you can add to these actions.
+
+ - **--contain**: Contain suggests that we want to better isolate the container runtime from the host. Adding the `--contain` flag will use minimal `/dev` and empty other directories (e.g., `/tmp`).
+ - **--containall**: In addition to what is provided with `--contain` (filesystems) also contain PID, IPC, and environment.
+ - **--cleanenv**: Clean the environment before running the container.
+ - **--pwd**: Initial working directory for payload process inside the container.
+
+This is **not** a complete list! Please see the `singularity <action> help` for an updated list.
+
+
+## Examples
+Here we are cleaning the environment. In the first command, we see that the variable `PEANUTBUTTER` gets passed into the container.
+
+```
+PEANUTBUTTER=JELLY singularity exec Centos7.img env | grep PEANUT
+PEANUTBUTTER=JELLY
+```
+
+And now here we add `--cleanenv` to see that it doesn't.
+
+
+```
+PEANUTBUTTER=JELLY singularity exec --cleanenv Centos7.img env | grep PEANUT
+```
+
+Here we will test contain. We can first confirm that there are a lot of files on our host in `/tmp`, and the same files are found in the container.
+
+```
+# On the host
+$ ls /tmp | wc -l
+17
+
+# And then /tmp is mounted to the container, by default
+$ singularity exec Centos7.img  ls /tmp | wc -l
+
+# ..but not if we use --contain
+$ singularity exec --contain Centos7.img  ls /tmp | wc -l
+0
+```

--- a/pages/docs/user-docs/action-run.md
+++ b/pages/docs/user-docs/action-run.md
@@ -36,7 +36,10 @@ $ singularity exec centos7.img cat /.singularity.d/runscript
 exec /bin/bash "$@"
 ```
 
-Notice how the runscript has bash followed by `$@`? This is good practice to include in a runscript, as any arguments passed by the user will be given to the container. Thus, I could send a command to the container for bash to run:
+Notice how the runscript has bash followed by `$@`? This is good practice to include in a runscript, as any arguments passed by the user will be given to the container.
+
+## Runtime Flags
+If you are interested in containing an environment or filesystem locations, we highly recommend that you look at the `singularity run help` and our documentation on [flags](/action-flags) to better customize this command.
 
 ## Examples
 In this example the container has a very simple runscript defined.

--- a/pages/docs/user-docs/action-shell.md
+++ b/pages/docs/user-docs/action-shell.md
@@ -25,7 +25,7 @@ Singularity centos7.img:~> echo $SHELL
 /bin/bash
 ```
 
-Additionally any arguments passed to the Singularity command (after the container name) will be passed to the called shell within the container, and shell can be used across image types. Here is a quick example of shelling into a container assembled from Docker layers.
+Additionally any arguments passed to the Singularity command (after the container name) will be passed to the called shell within the container, and shell can be used across image types. Here is a quick example of shelling into a container assembled from Docker layers. We highly recommend that you look at the `singularity shell help` and our documentation on [flags](/action-flags) to better customize this command.
 
 {% include asciicast.html source='shell_from_docker.js' uid='how-to-shell-from-docker' title='How to shell into container from Docker' author='davidgodlove@gmail.com'%}
 


### PR DESCRIPTION
This will address comments from the list that flags aren't mentioned for exec, shell, and run. This will need to be done with a more robust solution, but this should resolve the issue for now.