### PR TITLE
Remove extraneous static VER that pointed to an old version

### DIFF
--- a/pages/docs/user-docs/docs-installation.md
+++ b/pages/docs/user-docs/docs-installation.md
@@ -58,7 +58,6 @@ If you omit the `--sysconfdir` option , the configuration file will be installed
 The following commands will install a specific release from [GitHub releases page](https://github.com/singularityware/singularity/releases) to `/usr/local`.  
  
 ```
-$ VER=2.2.1
 $ VER={{ site.singularity_version }}
 $ wget https://github.com/singularityware/singularity/releases/download/$VER/singularity-$VER.tar.gz
 $ tar xvf singularity-$VER.tar.gz


### PR DESCRIPTION
The documentation uses `site.singularity_version` to print the current version. This commit removes an extra `VER` that was using an old version of Singularity.

Thanks!

--
Brie