### PR TITLE
Updated references to form and generated PDF on Registry page

### DIFF
--- a/pages/info/citation-registration.md
+++ b/pages/info/citation-registration.md
@@ -42,7 +42,7 @@ Please <a href="https://goo.gl/forms/tGBKnKwplNyRZRSm2" target="_blank">Register
 It is appreciated to add your site to the Singularity registry. Let us (and the world) know you are using Singularity!
 
 
-<a target="_blank" class="btn btn-primary navbar-btn cursorNorm" role="button" href="https://docs.google.com/forms/d/1-ZPL1inx4rb1wVTSVViA_W5Bn7P_eu_wUWUIcoFtPCw/prefill">Add to Registry</a> <a target="_blank" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vTKiQxi2asXGHbH1wqBavDkz8g6V2iNlvfDd0MBFg_0cC0SvWGdk1xvkT0TOKR6jg2aXvBC6oaevZ-S/pub?gid=143720890&single=true&output=pdf" class="no-after btn btn-primary navbar-btn cursorNorm" role="button">Download Registry  <i class="fa fa-file-pdf-o"></i></a>
+<a target="_blank" class="btn btn-primary navbar-btn cursorNorm" role="button" href="https://docs.google.com/forms/d/e/1FAIpQLScMgFwPXec2E-RM0uOB644eqbjl61UGYPpXRmjHABJGuMwcQQ/viewform">Add to Registry</a> <a target="_blank" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vTKiQxi2asXGHbH1wqBavDkz8g6V2iNlvfDd0MBFg_0cC0SvWGdk1xvkT0TOKR6jg2aXvBC6oaevZ-S/pub?gid=143720890&single=true&output=pdf" class="no-after btn btn-primary navbar-btn cursorNorm" role="button">Download Registry  <i class="fa fa-file-pdf-o"></i></a>
 
 
 ### Credits

--- a/pages/info/registry.md
+++ b/pages/info/registry.md
@@ -7,4 +7,4 @@ toc: false
 
 It is appreciated to add your site to the Singularity registry. Let us (and the world) know you are using Singularity!
 
-<a target="_blank" class="btn btn-primary navbar-btn cursorNorm" role="button" href="https://docs.google.com/forms/d/1-ZPL1inx4rb1wVTSVViA_W5Bn7P_eu_wUWUIcoFtPCw/prefill">Add to Registry</a> <a target="_blank" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vTKiQxi2asXGHbH1wqBavDkz8g6V2iNlvfDd0MBFg_0cC0SvWGdk1xvkT0TOKR6jg2aXvBC6oaevZ-S/pub?gid=143720890&single=true&output=pdf" class="no-after btn btn-primary navbar-btn cursorNorm" role="button">Download Registry  <i class="fa fa-file-pdf-o"></i></a>.
+<a target="_blank" class="btn btn-primary navbar-btn cursorNorm" role="button" href="https://docs.google.com/forms/d/e/1FAIpQLScMgFwPXec2E-RM0uOB644eqbjl61UGYPpXRmjHABJGuMwcQQ/viewform">Add to Registry</a> <a target="_blank" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vTKiQxi2asXGHbH1wqBavDkz8g6V2iNlvfDd0MBFg_0cC0SvWGdk1xvkT0TOKR6jg2aXvBC6oaevZ-S/pub?gid=143720890&single=true&output=pdf" class="no-after btn btn-primary navbar-btn cursorNorm" role="button">Download Registry  <i class="fa fa-file-pdf-o"></i></a>.

--- a/pages/info/registry.md
+++ b/pages/info/registry.md
@@ -7,6 +7,4 @@ toc: false
 
 It is appreciated to add your site to the Singularity registry. Let us (and the world) know you are using Singularity!
 
-<a target="_blank" class="btn btn-primary navbar-btn cursorNorm" role="button" href="https://goo.gl/forms/D7ed1dfLeNvml6no1">Add to Registry</a> <a target="_blank" href="https://docs.google.com/spreadsheets/d/1Vc_1prq_1WHGf0LWtpUBY-tfKdLLM_TErjnCe1mY5m0/pub?gid=1407658660&single=true&output=pdf" class="no-after btn btn-primary navbar-btn cursorNorm" role="button">Download Registry  <i class="fa fa-file-pdf-o"></i></a>.
-
-
+<a target="_blank" class="btn btn-primary navbar-btn cursorNorm" role="button" href="https://docs.google.com/forms/d/1-ZPL1inx4rb1wVTSVViA_W5Bn7P_eu_wUWUIcoFtPCw/prefill">Add to Registry</a> <a target="_blank" href="https://docs.google.com/spreadsheets/d/e/2PACX-1vTKiQxi2asXGHbH1wqBavDkz8g6V2iNlvfDd0MBFg_0cC0SvWGdk1xvkT0TOKR6jg2aXvBC6oaevZ-S/pub?gid=143720890&single=true&output=pdf" class="no-after btn btn-primary navbar-btn cursorNorm" role="button">Download Registry  <i class="fa fa-file-pdf-o"></i></a>.


### PR DESCRIPTION
Updated : form link not to show prefill but the submit form instead, and updated the links also on another page: http://singularity.lbl.gov/registry
Now those match citation-registration section as well.