### PR TITLE
Adding noindex metatag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
+<meta name="robots" content="noindex">
+
 {% include metadata.html %}
 
 <title>{{ page.title }} | {{ site.site_title }}</title>

--- a/_includes/head_print.html
+++ b/_includes/head_print.html
@@ -1,6 +1,9 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+
+<meta name="robots" content="noindex">
+
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{% if page.homepage == true %} {{site.homepage_title}} {% elsif page.title %}{{ page.title }}{% endif %}  | {{ site.site_title }}</title>


### PR DESCRIPTION
These docs currently still rank higher than the current official docs in search engine results. This will prevent this happening